### PR TITLE
Add rounded corners, white border and box shadow to content screenshots

### DIFF
--- a/configs/custom.css
+++ b/configs/custom.css
@@ -74,3 +74,12 @@ blockquote {
 .docs-next.button {
 	display:none;
 }
+
+article p img {
+    background-color: white;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 10px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    max-width: 90%;
+    padding: 5px;
+}


### PR DESCRIPTION
Marvin requested me to adjust the styles a bit to make sure screenshots stick out. Can only apply it to the pictures in the content paragraphs though. Didn't see any other pictures than screenshots.

### Before:

![Before](https://i.imgur.com/3Dto2SG.png)

### After:

![After](https://i.imgur.com/dppmqSY.png)