### PR TITLE
Adjust font sizes, add navigation bar hierarchy indicator line and more

### DIFF
--- a/configs/custom.css
+++ b/configs/custom.css
@@ -83,3 +83,39 @@ article p img {
     max-width: 90%;
     padding: 5px;
 }
+
+.headerWrapper header .logo {
+    margin-right: 15px;
+}
+
+.headerWrapper header .headerTitleWithLogo {
+    font-size: 1.05em;
+    font-weight: 400;
+}
+
+#docsNav .navGroup ul {
+    padding: 0 15px;
+    position: relative;
+}
+
+#docsNav .navGroup ul::before {
+    background-color: #e2e8f0;
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 1px;
+}
+
+.docsSliderActive .toc .toggleNav ul {
+    padding-left: 15px;
+}
+
+.toc .toggleNav ul li a {
+    font-size: 13px;
+}
+
+.toc .toggleNav .navGroup .navGroupCategoryTitle {
+    font-size: 15px;
+}


### PR DESCRIPTION
This pull requests improves the styles a bit.

First, we decreased the font size of the page title and the sidebar navigation on the left a bit. Additionally, we added a bit more spacing indicating the navigation hierarchy. On top of that, lines make it even easier to recognize the categories and its children. 

Tried to pick selectors that do not break other elements.