### PR TITLE
Remove extra space below pages by hiding article navigation container

### DIFF
--- a/configs/custom.css
+++ b/configs/custom.css
@@ -61,18 +61,8 @@ blockquote {
     opacity:1
 }
 
-.docs-prev.button {
-	display:none;
-}
-.docs-next.button {
-	display:none;
-}
-
-.docs-prev.button {
-	display:none;
-}
-.docs-next.button {
-	display:none;
+.docs-prevnext {
+    display: none;
 }
 
 article p img {


### PR DESCRIPTION
Someone did hide the next and previous article buttons but not the container around it which has margin. This introduces extra space below every post.