### PR TITLE
Replace favicon with dedicated image

### DIFF
--- a/configs/siteConfig.js
+++ b/configs/siteConfig.js
@@ -48,7 +48,7 @@ const siteConfig = {
   /* path to images for header/footer */
   headerIcon: 'img/favicon-32x32.png',
   footerIcon: 'img/favicon-32x32.png',
-  favicon: 'img/favicon-32x32.png',
+  favicon: 'img/favicon.png',
 
   /* Colors for website */
   colors: {


### PR DESCRIPTION
The logo is fine on the page, but in Firefox for example it is invisible for active tabs. Added a dedicated image with a background color to make sure the logo is visible all the time.