### PR TITLE
Create account security information page

### DIFF
--- a/de/account_security.md
+++ b/de/account_security.md
@@ -27,7 +27,7 @@ Entsprechend ist es sinnvoll für jede Seite ein anderes Passwort zu nutzen. Um 
 
 > Tipp: Bei [haveibeenpwned](https://haveibeenpwned.com/) kannst du unter Angabe deiner E-Mail Adresse kostenlos prüfen, ob diese in einem bekannten Leak einer Datenbank enthalten ist. Darüber hinaus erhältst du Informationen darüber, auf welcher Seite der Vorfall stattgefunden hat und welche Daten entwenden wurden.
 
-![haveibeenpwned Beispiel](https://i.imgur.com/aoaxHEq.jpg)
+![haveibeenpwned Beispiel](https://screensaver01.zap-hosting.com/index.php/apps/files_sharing/publicpreview/ss4yJPQiN4rQXY3?x=2560&y=553&a=true&file=firefox_skyHqus4yD.png&scalingup=0)
 
 ## 🔧 Account Einstellungen
 

--- a/de/account_security.md
+++ b/de/account_security.md
@@ -4,7 +4,7 @@ title: Sicherheit
 sidebar_label: Sicherheit
 ---
 
-Dein Account bei uns gibt Zugang zu deinen Diensten, entsprechend ist Sicherheit - besonders in der heutigen Zeit - sehr wichtig. Wir versuchen von unserer Seite zu tun was wir können, um dich zu schützen. Beispielsweise bieten wir Belohnungen für Meldungen zu Sicherheitslücken für Whitehat Hacker in [unserem Bug Bounty Programm](https://zap-hosting.com/de/sicherheit/) an.
+Dein Account bei uns gibt Zugang zu deinen Diensten, entsprechend ist Sicherheit - besonders in der heutigen Zeit - sehr wichtig. Wir versuchen von unserer Seite zu tun was wir können, um dich zu schützen. Beispielsweise bieten wir Belohnungen für Meldungen zu Sicherheitslücken für Whitehat Hacker in [unserem Bug Bounty Programm](https://zap-hosting.com/de/sicherheit/) an.  
 Zur Sicherheit deines Accounts gehören aber zwei Seiten, deshalb hier einige Informationen, wie du deinen Account besser schützen kannst.
 
 ## 🔑 Sichere Passwörter
@@ -22,7 +22,8 @@ Solltest du, wie im nächsten Schritt empfohlen, einen Passwörter Manager nutze
 
 ## 🔃 🚫 Passwörter nur einmal verwenden
 
-Durch ein sicheres Passwort machst du es Angreifern schwerer, automatisiert oder durch Raten Zugang zu deinem Account zu erlangen. Allerdings ist es wichtig ein Passwort im Bestfall nicht mehrmals, also auf verschiedenen Webseiten und Diensten, zu verwenden. Sollte es bei einem deiner genutzten Anbieter und Webseiten zu einem Sicherheitsproblem kommen, bei dem dein Passwort in die falschen Hände gerät, sind deine Accounts bei anderen Webseiten ebenfalls in Gefahr. Entsprechend ist es sinnvoll für jede Seite ein anderes Passwort zu nutzen. Um die Passwörter nicht durcheinander zu bringen oder zu vergessen, ist ein Passwortmanager wie beispielsweise [KeePass](https://keepass.info/) empfehlenswert.
+Durch ein sicheres Passwort machst du es Angreifern schwerer, automatisiert oder durch Raten Zugang zu deinem Account zu erlangen. Allerdings ist es wichtig ein Passwort im Bestfall nicht mehrmals, also auf verschiedenen Webseiten und Diensten, zu verwenden. Sollte es bei einem deiner genutzten Anbieter und Webseiten zu einem Sicherheitsproblem kommen, bei dem dein Passwort in die falschen Hände gerät, sind deine Accounts bei anderen Webseiten ebenfalls in Gefahr.  
+Entsprechend ist es sinnvoll für jede Seite ein anderes Passwort zu nutzen. Um die Passwörter nicht durcheinander zu bringen oder zu vergessen, ist ein Passwortmanager wie beispielsweise [KeePass](https://keepass.info/) empfehlenswert.
 
 > Tipp: Bei [haveibeenpwned](https://haveibeenpwned.com/) kannst du unter Angabe deiner E-Mail Adresse kostenlos prüfen, ob diese in einem bekannten Leak einer Datenbank enthalten ist. Darüber hinaus erhältst du Informationen darüber, auf welcher Seite der Vorfall stattgefunden hat und welche Daten entwenden wurden.
 

--- a/de/account_security.md
+++ b/de/account_security.md
@@ -4,7 +4,7 @@ title: Sicherheit
 sidebar_label: Sicherheit
 ---
 
-Dein Account bei uns gibt Zugang zu deinen Diensten, entsprechend ist Sicherheit - besonders in der heutigen Zeit - sehr wichtig. Wir versuchen von unser Seite zu tun was wir können, um dich zu schützen. Beispielsweise bieten wir Belohnungen für Meldungen zu Sicherheitslücken für Whitehat Hacker in [unserem Bug Bounty Programm](https://zap-hosting.com/de/sicherheit/) an.
+Dein Account bei uns gibt Zugang zu deinen Diensten, entsprechend ist Sicherheit - besonders in der heutigen Zeit - sehr wichtig. Wir versuchen von unserer Seite zu tun was wir können, um dich zu schützen. Beispielsweise bieten wir Belohnungen für Meldungen zu Sicherheitslücken für Whitehat Hacker in [unserem Bug Bounty Programm](https://zap-hosting.com/de/sicherheit/) an.
 Zur Sicherheit deines Accounts gehören aber zwei Seiten, deshalb hier einige Informationen, wie du deinen Account besser schützen kannst.
 
 ## 🔑 Sichere Passwörter

--- a/de/account_security.md
+++ b/de/account_security.md
@@ -1,0 +1,41 @@
+---
+id: account_security
+title: Sicherheit
+sidebar_label: Sicherheit
+---
+
+Dein Account bei uns gibt Zugang zu deinen Diensten, entsprechend ist Sicherheit - besonders in der heutigen Zeit - sehr wichtig. Wir versuchen von unser Seite zu tun was wir können, um dich zu schützen. Beispielsweise bieten wir Belohnungen für Meldungen zu Sicherheitslücken für Whitehat Hacker in [unserem Bug Bounty Programm](https://zap-hosting.com/de/sicherheit/) an.
+Zur Sicherheit deines Accounts gehören aber zwei Seiten, deshalb hier einige Informationen, wie du deinen Account besser schützen kannst.
+
+## 🔑 Sichere Passwörter
+
+Dein Passwort ist ein zentraler Bestandteil um zu prüfen, ob eine Person Zugang zu deinem Account erhalten darf oder nicht. Dadurch ist es wichtig dein Passwort so zu gestalten, dass es möglichst nicht von anderen benutzt wird (z.B. typische Passwörter wie 123456), eine gewisse Mindestlänge und Komplexität erreicht und nicht durch Informationen zu dir und deiner Person erraten werden kann (z.B. Geburtsdaten).
+
+Ein solides Passwort kannst du z.B. durch das Bilden eines Satzes erfinden.
+
+**I**ch **f**ahre **i**m **S**ommer **i**n **d**ie **B**erge **,** **d**ort **w**erde **i**ch **S**ki **f**ahren **w**eil **e**s **d**ort **0** **G**rad **k**alt **i**st **.**
+
+Fügst du nun die Anfangsbuchstaben der Wörter, Satzzeichen und Zahlen zusammen, hast du ein schwer zu erratendes Passwort mit einer gewissen Komplexität, was man sich durch den Satz merken kann:
+IfiSidB,wiSfwed0Gki.
+
+Solltest du, wie im nächsten Schritt empfohlen, einen Passwörter Manager nutzen, so kannst du dort in der Regel direkt ein gutes Passwort generieren und musst es dir nicht merken.
+
+## 🔃 🚫 Passwörter nur einmal verwenden
+
+Durch ein sicheres Passwort machst du es Angreifern schwerer, automatisiert oder durch Raten Zugang zu deinem Account zu erlangen. Allerdings ist es wichtig ein Passwort im Bestfall nicht mehrmals, also auf verschiedenen Webseiten und Diensten, zu verwenden. Sollte es bei einem deiner genutzten Anbieter und Webseiten zu einem Sicherheitsproblem kommen, bei dem dein Passwort in die falschen Hände gerät, sind deine Accounts bei anderen Webseiten ebenfalls in Gefahr. Entsprechend ist es sinnvoll für jede Seite ein anderes Passwort zu nutzen. Um die Passwörter nicht durcheinander zu bringen oder zu vergessen, ist ein Passwortmanager wie beispielsweise [KeePass](https://keepass.info/) empfehlenswert.
+
+> Tipp: Bei [haveibeenpwned](https://haveibeenpwned.com/) kannst du unter Angabe deiner E-Mail Adresse kostenlos prüfen, ob diese in einem bekannten Leak einer Datenbank enthalten ist. Darüber hinaus erhältst du Informationen darüber, auf welcher Seite der Vorfall stattgefunden hat und welche Daten entwenden wurden.
+
+![haveibeenpwned Beispiel](https://i.imgur.com/aoaxHEq.jpg)
+
+## 🔧 Account Einstellungen
+
+Neben der [2-Factor Authentication](/docs/de/account_2factor/) kannst du im Reiter [Sicherheit](https://zap-hosting.com/de/customer/home/security/) in deinem Account auch OneClick Login deaktivieren. In einigen E-Mails versenden wir Links, durch die du per Klick eingeloggt wirst und direkt zur relevanten Seite im jeweiligen Kontext geleitet wirst. Grundsätzlich versendet man keine sensiblen Informationen per E-Mail. Entsprechend ist es für Accounts mit Zugriff zu wichtigen Diensten sinnvoll, die Funktion gegebenenfalls auszuschalten.
+
+## 🚨 Ich wurde gehackt
+
+Solltest du dennoch einem Angriff zum Opfer fallen, bei dem sich Unbefugte Zugang zu deinem Account verschaffen, haben wir Systeme implementiert, um den Schaden zu minimieren und dir zu helfen, möglichst schnell wieder Herr der Lage zu werden.
+
+Die in deinem Account hinterlegte E-Mail Adresse kann bei bestätigten Accounts nur geändert werden, wenn beide E-Mail Adressen (aktuelle E-Mail Adresse und gewünschte neue Adresse) die Änderung bestätigen. Entsprechend kannst du, sobald dir Ungereimtheiten aufallen, sofort dein Passwort mit deiner aktuellen E-Mail Adresse zurücksetzen. Bei einer Passwortänderung werden alle bestehenden Sessions aufgefordert, sich neu einzuloggen. Dadurch solltest du den Angreifer schnell aussperren können.
+
+Bei Unklarheiten und sonstigen Fragen, sind wir im Support natürlich immer gerne für dich da um im Notfall zu helfen, wo wir können.

--- a/en/account_security.md
+++ b/en/account_security.md
@@ -1,0 +1,44 @@
+---
+id: account_security
+title: Sicherheit
+sidebar_label: Sicherheit
+---
+
+(For translation)
+
+Dein Account bei uns gibt Zugang zu deinen Diensten, entsprechend ist Sicherheit - besonders in der heutigen Zeit - sehr wichtig. Wir versuchen von unserer Seite zu tun was wir können, um dich zu schützen. Beispielsweise bieten wir Belohnungen für Meldungen zu Sicherheitslücken für Whitehat Hacker in [unserem Bug Bounty Programm](https://zap-hosting.com/de/sicherheit/) an.  
+Zur Sicherheit deines Accounts gehören aber zwei Seiten, deshalb hier einige Informationen, wie du deinen Account besser schützen kannst.
+
+## 🔑 Sichere Passwörter
+
+Dein Passwort ist ein zentraler Bestandteil um zu prüfen, ob eine Person Zugang zu deinem Account erhalten darf oder nicht. Dadurch ist es wichtig dein Passwort so zu gestalten, dass es möglichst nicht von anderen benutzt wird (z.B. typische Passwörter wie 123456), eine gewisse Mindestlänge und Komplexität erreicht und nicht durch Informationen zu dir und deiner Person erraten werden kann (z.B. Geburtsdaten).
+
+Ein solides Passwort kannst du z.B. durch das Bilden eines Satzes erfinden.
+
+**I**ch **f**ahre **i**m **S**ommer **i**n **d**ie **B**erge **,** **d**ort **w**erde **i**ch **S**ki **f**ahren **w**eil **e**s **d**ort **0** **G**rad **k**alt **i**st **.**
+
+Fügst du nun die Anfangsbuchstaben der Wörter, Satzzeichen und Zahlen zusammen, hast du ein schwer zu erratendes Passwort mit einer gewissen Komplexität, was man sich durch den Satz merken kann:
+IfiSidB,wiSfwed0Gki.
+
+Solltest du, wie im nächsten Schritt empfohlen, einen Passwörter Manager nutzen, so kannst du dort in der Regel direkt ein gutes Passwort generieren und musst es dir nicht merken.
+
+## 🔃 🚫 Passwörter nur einmal verwenden
+
+Durch ein sicheres Passwort machst du es Angreifern schwerer, automatisiert oder durch Raten Zugang zu deinem Account zu erlangen. Allerdings ist es wichtig ein Passwort im Bestfall nicht mehrmals, also auf verschiedenen Webseiten und Diensten, zu verwenden. Sollte es bei einem deiner genutzten Anbieter und Webseiten zu einem Sicherheitsproblem kommen, bei dem dein Passwort in die falschen Hände gerät, sind deine Accounts bei anderen Webseiten ebenfalls in Gefahr.  
+Entsprechend ist es sinnvoll für jede Seite ein anderes Passwort zu nutzen. Um die Passwörter nicht durcheinander zu bringen oder zu vergessen, ist ein Passwortmanager wie beispielsweise [KeePass](https://keepass.info/) empfehlenswert.
+
+> Tipp: Bei [haveibeenpwned](https://haveibeenpwned.com/) kannst du unter Angabe deiner E-Mail Adresse kostenlos prüfen, ob diese in einem bekannten Leak einer Datenbank enthalten ist. Darüber hinaus erhältst du Informationen darüber, auf welcher Seite der Vorfall stattgefunden hat und welche Daten entwenden wurden.
+
+![haveibeenpwned Beispiel](https://i.imgur.com/aoaxHEq.jpg)
+
+## 🔧 Account Einstellungen
+
+Neben der [2-Factor Authentication](/docs/de/account_2factor/) kannst du im Reiter [Sicherheit](https://zap-hosting.com/de/customer/home/security/) in deinem Account auch OneClick Login deaktivieren. In einigen E-Mails versenden wir Links, durch die du per Klick eingeloggt wirst und direkt zur relevanten Seite im jeweiligen Kontext geleitet wirst. Grundsätzlich versendet man keine sensiblen Informationen per E-Mail. Entsprechend ist es für Accounts mit Zugriff zu wichtigen Diensten sinnvoll, die Funktion gegebenenfalls auszuschalten.
+
+## 🚨 Ich wurde gehackt
+
+Solltest du dennoch einem Angriff zum Opfer fallen, bei dem sich Unbefugte Zugang zu deinem Account verschaffen, haben wir Systeme implementiert, um den Schaden zu minimieren und dir zu helfen, möglichst schnell wieder Herr der Lage zu werden.
+
+Die in deinem Account hinterlegte E-Mail Adresse kann bei bestätigten Accounts nur geändert werden, wenn beide E-Mail Adressen (aktuelle E-Mail Adresse und gewünschte neue Adresse) die Änderung bestätigen. Entsprechend kannst du, sobald dir Ungereimtheiten aufallen, sofort dein Passwort mit deiner aktuellen E-Mail Adresse zurücksetzen. Bei einer Passwortänderung werden alle bestehenden Sessions aufgefordert, sich neu einzuloggen. Dadurch solltest du den Angreifer schnell aussperren können.
+
+Bei Unklarheiten und sonstigen Fragen, sind wir im Support natürlich immer gerne für dich da um im Notfall zu helfen, wo wir können.

--- a/sidebars.json
+++ b/sidebars.json
@@ -23,7 +23,8 @@
 		  "account_cashbox",
 		  "account_usermanagement",
 		  "account_vouchers",
-		  "account_donations"
+		  "account_donations",
+		  "account_security"
 	   ],
 	   "Gameserver - General":[
 		  "gameserver_cloudvslifetime",


### PR DESCRIPTION
Adds a start for a basic account security information page in German. The haveibeenpwned screenshot needs to be replaced with the ZAP screensaver.

English page for the American team to translate to be added.