### PR TITLE
Hotfix: Replaces internal linking with direct links for content through react components

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -23,65 +23,65 @@ We cover a wide range of topics and regularly update our content to ensure you'r
 Perfect and utilize the full extent of your game server. With our expertise, we take your gaming to a new level. Our detailed guides for over 50 different games and their extensions/modifications enable you to develop a deep understanding of configuring and managing your game servers.
 
 <Cards>
-    <Card title="7 Days to Die" description="Placeholder" link="7d2d-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/dXbYWLtmqHnAz8n/preview"/>
-    <Card title="Abiotic Factor" description="Placeholder" link="abioticfactor-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/ktTGqHAKnPH6rya/preview"/>
-    <Card title="American Truck Simulator" description="Placeholder" link="ats-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/MEJfqyT5YwYpjpW/preview"/>
-    <Card title="Among Us" description="Placeholder" link="amongus-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/56aajb26cS6Lda3/preview"/>
-    <Card title="ARK" description="Placeholder" link="ark-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/qnWELD8ik9srBDG/preview"/>
-    <Card title="Arma 3" description="Placeholder" link="arma3-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/J3X8RGWSZ5MgFNq/preview"/>
-    <Card title="Assetto Corsa" description="Placeholder" link="assettocorsa-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/z8SQ7C2fkcJmWYj/preview"/>
-    <Card title="Assetto Corsa (Comp.)" description="Placeholder" link="assetto-competizione-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/oLbXej9nzXPc6Kr/preview"/>
-    <Card title="Avorion" description="Placeholder" link="avorion-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/FGtbBbgYsjygaHQ/preview"/>
-    <Card title="Barotrauma" description="Placeholder" link="barotrauma-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/CRf8AAmcXwAReHT/preview"/>
-    <Card title="BeamMP" description="Placeholder" link="beammp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/XLLGT8nMkoXKYtC/preview"/>
-    <Card title="Conan Exiles" description="Placeholder" link="conan-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Kf4Agc6HXkEMJGM/preview"/>
-    <Card title="Core Keeper" description="Placeholder" link="corekeeper-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/RsHHfMtbAdY4pJf/preview"/>
-    <Card title="CS 1.6" description="Placeholder" link="cs16-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/q5enKNatKZMpXPf/preview"/>
-    <Card title="CS:GO" description="Placeholder" link="csgo-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/cSkWS3sQb22s5f8/preview"/>
-    <Card title="CS:S" description="Placeholder" link="css-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/PqQqSqgin9BjJtw/preview"/>
-    <Card title="CS2" description="Placeholder" link="cs2-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/cSkWS3sQb22s5f8/preview"/>
-    <Card title="DayZ" description="Placeholder" link="dayz-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/pnsf69ApNAWxzEa/preview"/>
-    <Card title="Don't Starve Together" description="Placeholder" link="dst-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/rtFRzgDkWPZodc4/preview"/>
-    <Card title="ECO" description="Placeholder" link="eco-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/XiHGRrHtkqnsNF7/preview"/>
-    <Card title="Empyrion" description="Placeholder" link="empyrion-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/xYyDybq5znjy3HR/preview"/>
-    <Card title="Enshrouded" description="Placeholder" link="enshrouded-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/65zgmLrBtcPTt7k/preview"/>
-    <Card title="Euro Truck Simulator" description="Placeholder" link="ets2-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/yZX6rF6emyBbrgq/preview"/>
-    <Card title="Factorio" description="Placeholder" link="factorio-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/iZeioXS2ZPHrnjq/preview"/>
-    <Card title="FiveM" description="Placeholder" link="fivem-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/2JA2yD8CgCpn3nZ/preview"/>
-    <Card title="Foundry" description="Placeholder" link="foundry-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/meb8kopKD3WETbt/preview"/>
-    <Card title="Garry's Mod" description="Placeholder" link="gmod-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/LddW8FyQ2ZKKTzN/preview"/>
-    <Card title="Last Oasis" description="Placeholder" link="lastoasis-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/3CwdeqDaikA6Mp8/preview"/>
-    <Card title="Minecraft" description="Placeholder" link="minecraft-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/nQ5nkPeAN25dJaf/preview"/>
-    <Card title="Multi Theft Auto" description="Placeholder" link="mta-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/MjAJfQFWBprjdk3/preview"/>
-    <Card title="Myth of Empires" description="Placeholder" link="moe-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/W8rBp8LESZidDLs/preview"/>
-    <Card title="Open.mp" description="Placeholder" link="openmp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/JwKCDWdigbHag3C/preview"/>
-    <Card title="Palworld" description="Placeholder" link="palworld-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/RgdKJoRRNBPcT5r/preview"/>
-    <Card title="Project Zomboid" description="Placeholder" link="projectzomboid-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/tYJB3JWdG9ewAmf/preview"/>
-    <Card title="RedM" description="Placeholder" link="redm-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/9HTK29mQCHe5kNs/preview"/>
-    <Card title="RimWorld Together" description="Placeholder" link="rimworldtogether-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/7PBDBpc2ysJPWdA/preview"/>
-    <Card title="Rust" description="Placeholder" link="rust-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/G82jnYsbexscj5W/preview"/>
-    <Card title="Satisfactory" description="Placeholder" link="satisfactory-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/JFfEJs6E5ExjYmD/preview"/>
-    <Card title="SCP: Secret Laboratory" description="Placeholder" link="scp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/b5qWPyQeoB5wN8s/preview"/>
-    <Card title="Space Engineers" description="Placeholder" link="spaceengineers-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Wi29doTRKNHGn2a/preview"/>
-    <Card title="Stormworks" description="Placeholder" link="stormworks-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/wzDPFmpDJ8oZTtW/preview"/>
-    <Card title="Sunkenland" description="Placeholder" link="sunkenland-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/F8eyGq2GjKYcNcb/preview"/>
-    <Card title="Terraria" description="Placeholder" link="terraria-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/eByW7ZDwsmySJr9/preview"/>
-    <Card title="Terratech Worlds" description="Placeholder" link="terratech-worlds-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Sf4LScK23KCxzDF/preview"/>
-    <Card title="Unturned" description="Placeholder" link="unturned-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/GTxekqqTxQyttDS/preview"/>
-    <Card title="Valheim" description="Placeholder" link="valheim-firststeps-dashboard"  image="https://screensaver01.zap-hosting.com/index.php/s/LSiFMXMmyKgo4LG/preview"/>
-    <Card title="Vein" description="Placeholder" link="vein-firststeps-dashboard"  image="https://screensaver01.zap-hosting.com/index.php/s/mBkRqP68YrDmdop/preview"/>
-    <Card title="V Rising" description="Placeholder" link="vrising-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/xazMeLwLJTJG7LF/preview"/>
-    <Card title="Wurm Unlimited" description="Placeholder" link="wurmunlimited-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/BzbDjJWySW4LjtX/preview"/>
+    <Card title="7 Days to Die" description="Placeholder" link="https://zap-hosting.com/guides/docs/7d2d-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/dXbYWLtmqHnAz8n/preview"/>
+    <Card title="Abiotic Factor" description="Placeholder" link="https://zap-hosting.com/guides/docs/abioticfactor-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/ktTGqHAKnPH6rya/preview"/>
+    <Card title="American Truck Simulator" description="Placeholder" link="https://zap-hosting.com/guides/docs/ats-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/MEJfqyT5YwYpjpW/preview"/>
+    <Card title="Among Us" description="Placeholder" link="https://zap-hosting.com/guides/docs/amongus-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/56aajb26cS6Lda3/preview"/>
+    <Card title="ARK" description="Placeholder" link="https://zap-hosting.com/guides/docs/ark-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/qnWELD8ik9srBDG/preview"/>
+    <Card title="Arma 3" description="Placeholder" link="https://zap-hosting.com/guides/docs/arma3-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/J3X8RGWSZ5MgFNq/preview"/>
+    <Card title="Assetto Corsa" description="Placeholder" link="https://zap-hosting.com/guides/docs/assettocorsa-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/z8SQ7C2fkcJmWYj/preview"/>
+    <Card title="Assetto Corsa (Comp.)" description="Placeholder" link="https://zap-hosting.com/guides/docs/assetto-competizione-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/oLbXej9nzXPc6Kr/preview"/>
+    <Card title="Avorion" description="Placeholder" link="https://zap-hosting.com/guides/docs/avorion-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/FGtbBbgYsjygaHQ/preview"/>
+    <Card title="Barotrauma" description="Placeholder" link="https://zap-hosting.com/guides/docs/barotrauma-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/CRf8AAmcXwAReHT/preview"/>
+    <Card title="BeamMP" description="Placeholder" link="https://zap-hosting.com/guides/docs/beammp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/XLLGT8nMkoXKYtC/preview"/>
+    <Card title="Conan Exiles" description="Placeholder" link="https://zap-hosting.com/guides/docs/conan-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Kf4Agc6HXkEMJGM/preview"/>
+    <Card title="Core Keeper" description="Placeholder" link="https://zap-hosting.com/guides/docs/corekeeper-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/RsHHfMtbAdY4pJf/preview"/>
+    <Card title="CS 1.6" description="Placeholder" link="https://zap-hosting.com/guides/docs/cs16-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/q5enKNatKZMpXPf/preview"/>
+    <Card title="CS:GO" description="Placeholder" link="https://zap-hosting.com/guides/docs/csgo-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/cSkWS3sQb22s5f8/preview"/>
+    <Card title="CS:S" description="Placeholder" link="https://zap-hosting.com/guides/docs/css-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/PqQqSqgin9BjJtw/preview"/>
+    <Card title="CS2" description="Placeholder" link="https://zap-hosting.com/guides/docs/cs2-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/cSkWS3sQb22s5f8/preview"/>
+    <Card title="DayZ" description="Placeholder" link="https://zap-hosting.com/guides/docs/dayz-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/pnsf69ApNAWxzEa/preview"/>
+    <Card title="Don't Starve Together" description="Placeholder" link="https://zap-hosting.com/guides/docs/dst-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/rtFRzgDkWPZodc4/preview"/>
+    <Card title="ECO" description="Placeholder" link="https://zap-hosting.com/guides/docs/eco-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/XiHGRrHtkqnsNF7/preview"/>
+    <Card title="Empyrion" description="Placeholder" link="https://zap-hosting.com/guides/docs/empyrion-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/xYyDybq5znjy3HR/preview"/>
+    <Card title="Enshrouded" description="Placeholder" link="https://zap-hosting.com/guides/docs/enshrouded-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/65zgmLrBtcPTt7k/preview"/>
+    <Card title="Euro Truck Simulator" description="Placeholder" link="https://zap-hosting.com/guides/docs/ets2-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/yZX6rF6emyBbrgq/preview"/>
+    <Card title="Factorio" description="Placeholder" link="https://zap-hosting.com/guides/docs/factorio-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/iZeioXS2ZPHrnjq/preview"/>
+    <Card title="FiveM" description="Placeholder" link="https://zap-hosting.com/guides/docs/fivem-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/2JA2yD8CgCpn3nZ/preview"/>
+    <Card title="Foundry" description="Placeholder" link="https://zap-hosting.com/guides/docs/foundry-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/meb8kopKD3WETbt/preview"/>
+    <Card title="Garry's Mod" description="Placeholder" link="https://zap-hosting.com/guides/docs/gmod-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/LddW8FyQ2ZKKTzN/preview"/>
+    <Card title="Last Oasis" description="Placeholder" link="https://zap-hosting.com/guides/docs/lastoasis-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/3CwdeqDaikA6Mp8/preview"/>
+    <Card title="Minecraft" description="Placeholder" link="https://zap-hosting.com/guides/docs/minecraft-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/nQ5nkPeAN25dJaf/preview"/>
+    <Card title="Multi Theft Auto" description="Placeholder" link="https://zap-hosting.com/guides/docs/mta-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/MjAJfQFWBprjdk3/preview"/>
+    <Card title="Myth of Empires" description="Placeholder" link="https://zap-hosting.com/guides/docs/moe-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/W8rBp8LESZidDLs/preview"/>
+    <Card title="Open.mp" description="Placeholder" link="https://zap-hosting.com/guides/docs/openmp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/JwKCDWdigbHag3C/preview"/>
+    <Card title="Palworld" description="Placeholder" link="https://zap-hosting.com/guides/docs/palworld-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/RgdKJoRRNBPcT5r/preview"/>
+    <Card title="Project Zomboid" description="Placeholder" link="https://zap-hosting.com/guides/docs/projectzomboid-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/tYJB3JWdG9ewAmf/preview"/>
+    <Card title="RedM" description="Placeholder" link="https://zap-hosting.com/guides/docs/redm-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/9HTK29mQCHe5kNs/preview"/>
+    <Card title="RimWorld Together" description="Placeholder" link="https://zap-hosting.com/guides/docs/rimworldtogether-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/7PBDBpc2ysJPWdA/preview"/>
+    <Card title="Rust" description="Placeholder" link="https://zap-hosting.com/guides/docs/rust-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/G82jnYsbexscj5W/preview"/>
+    <Card title="Satisfactory" description="Placeholder" link="https://zap-hosting.com/guides/docs/satisfactory-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/JFfEJs6E5ExjYmD/preview"/>
+    <Card title="SCP: Secret Laboratory" description="Placeholder" link="https://zap-hosting.com/guides/docs/scp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/b5qWPyQeoB5wN8s/preview"/>
+    <Card title="Space Engineers" description="Placeholder" link="https://zap-hosting.com/guides/docs/spaceengineers-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Wi29doTRKNHGn2a/preview"/>
+    <Card title="Stormworks" description="Placeholder" link="https://zap-hosting.com/guides/docs/stormworks-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/wzDPFmpDJ8oZTtW/preview"/>
+    <Card title="Sunkenland" description="Placeholder" link="https://zap-hosting.com/guides/docs/sunkenland-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/F8eyGq2GjKYcNcb/preview"/>
+    <Card title="Terraria" description="Placeholder" link="https://zap-hosting.com/guides/docs/terraria-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/eByW7ZDwsmySJr9/preview"/>
+    <Card title="Terratech Worlds" description="Placeholder" link="https://zap-hosting.com/guides/docs/terratech-worlds-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Sf4LScK23KCxzDF/preview"/>
+    <Card title="Unturned" description="Placeholder" link="https://zap-hosting.com/guides/docs/unturned-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/GTxekqqTxQyttDS/preview"/>
+    <Card title="Valheim" description="Placeholder" link="https://zap-hosting.com/guides/docs/valheim-firststeps-dashboard"  image="https://screensaver01.zap-hosting.com/index.php/s/LSiFMXMmyKgo4LG/preview"/>
+    <Card title="Vein" description="Placeholder" link="https://zap-hosting.com/guides/docs/vein-firststeps-dashboard"  image="https://screensaver01.zap-hosting.com/index.php/s/mBkRqP68YrDmdop/preview"/>
+    <Card title="V Rising" description="Placeholder" link="https://zap-hosting.com/guides/docs/vrising-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/xazMeLwLJTJG7LF/preview"/>
+    <Card title="Wurm Unlimited" description="Placeholder" link="https://zap-hosting.com/guides/docs/wurmunlimited-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/BzbDjJWySW4LjtX/preview"/>
 </Cards>
 
 ## vRootserver
 Utilize the full extent of your vRoot server (VPS/Root server) with our comprehensive guides. Whether you prefer Linux or Windows, our guides help you efficiently set up and manage your server.
 
 <Cards>
-    <Card title="VPS (Linux)" description="Placeholder" link="vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/XmJGtYkc7d9rBai/preview" type="product-categories"/>
-    <Card title="VPS (Windows)" description="Placeholder" link="vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/XmJGtYkc7d9rBai/preview" type="product-categories"/>
-    <Card title="Root server (Linux)" description="Placeholder" link="vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/fqn5SZYRJjoikXa/preview" type="product-categories"/>
-    <Card title="Root server (Windows)" description="Placeholder" link="vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/fqn5SZYRJjoikXa/preview" type="product-categories"/>
+    <Card title="VPS (Linux)" description="Placeholder" link="https://zap-hosting.com/guides/docs/vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/XmJGtYkc7d9rBai/preview" type="product-categories"/>
+    <Card title="VPS (Windows)" description="Placeholder" link="https://zap-hosting.com/guides/docs/vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/XmJGtYkc7d9rBai/preview" type="product-categories"/>
+    <Card title="Root server (Linux)" description="Placeholder" link="https://zap-hosting.com/guides/docs/vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/fqn5SZYRJjoikXa/preview" type="product-categories"/>
+    <Card title="Root server (Windows)" description="Placeholder" link="https://zap-hosting.com/guides/docs/vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/fqn5SZYRJjoikXa/preview" type="product-categories"/>
 </Cards>
 
 ## Dedicated Server
@@ -89,21 +89,21 @@ Utilize the full extent of your vRoot server (VPS/Root server) with our comprehe
 Our dedicated servers offer performance for demanding projects. Discover in our guides how to configure the hardware and operating systems according to your needs and ensure that your applications run optimally.
 
 <Cards>
-    <Card title="Dedicated Server" description="Placeholder" link="dedicated-introduction" image="https://screensaver01.zap-hosting.com/index.php/s/o5kTJsSdwGY69m8/preview" type="product-categories"/>
+    <Card title="Dedicated Server" description="Placeholder" link="https://zap-hosting.com/guides/docs/dedicated-introduction" image="https://screensaver01.zap-hosting.com/index.php/s/o5kTJsSdwGY69m8/preview" type="product-categories"/>
 </Cards>
 
 ## Domain & Webspace
 Start your online project on a solid foundation with easily understandable guides on domain registration and webspace management. We guide you through every step, from setup to publishing your website.
 
 <Cards>
-    <Card title="Domain" description="Placeholder" link="domain-introduction" image="https://screensaver01.zap-hosting.com/index.php/s/CHKT8d4ARD8sqZE/preview" type="product-categories"/>
-    <Card title="Webspace" description="Placeholder" link="webspace-adddomain" image="https://screensaver01.zap-hosting.com/index.php/s/CHKT8d4ARD8sqZE/preview" type="product-categories"/>
+    <Card title="Domain" description="Placeholder" link="https://zap-hosting.com/guides/docs/domain-introduction" image="https://screensaver01.zap-hosting.com/index.php/s/CHKT8d4ARD8sqZE/preview" type="product-categories"/>
+    <Card title="Webspace" description="Placeholder" link="https://zap-hosting.com/guides/docs/webspace-adddomain" image="https://screensaver01.zap-hosting.com/index.php/s/CHKT8d4ARD8sqZE/preview" type="product-categories"/>
 </Cards>
 
 ## Voicebot & Voiceserver
 Enhance your online interactions with our voicebots and voice servers. Our guides make the setup easy, so you can spend more time with your community, whether it's gaming or in meetings.
 
 <Cards>
-    <Card title="Voicebot" description="Placeholder" link="voiceserver-voicebot-connection" image="https://screensaver01.zap-hosting.com/index.php/s/zZ73fps5Eq93foK/preview" type="product-categories"/>
-    <Card title="Voiceserver" description="Placeholder" link="voiceserver-becomeadmin" image="https://screensaver01.zap-hosting.com/index.php/s/6cxS6Mo93YL6X5K/preview" type="product-categories"/>
+    <Card title="Voicebot" description="Placeholder" link="https://zap-hosting.com/guides/docs/voiceserver-voicebot-connection" image="https://screensaver01.zap-hosting.com/index.php/s/zZ73fps5Eq93foK/preview" type="product-categories"/>
+    <Card title="Voiceserver" description="Placeholder" link="https://zap-hosting.com/guides/docs/voiceserver-becomeadmin" image="https://screensaver01.zap-hosting.com/index.php/s/6cxS6Mo93YL6X5K/preview" type="product-categories"/>
 </Cards>

--- a/i18n/de/docusaurus-plugin-content-docs/current/welcome.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/welcome.md
@@ -22,86 +22,86 @@ Wir decken eine breite Palette an Themen ab und aktualisieren unsere Inhalte reg
 Perfektioniere und Nutze den vollen Umfang deines Gameservers. Mit unserer Expertise bringen wir dein Gaming auf ein neues Level. Unsere detaillierten Anleitungen für über 50 verschiedene Spiele und die dazugehörigen Erweiterungen/Modifikationen ermöglichen es dir, ein tiefgreifendes Verständnis für die Konfiguration und Verwaltung deiner Gameserver zu entwickeln.
 
 <Cards>
-    <Card title="7 Days to Die" description="Placeholder" link="7d2d-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/dXbYWLtmqHnAz8n/preview"/>
-    <Card title="Abiotic Factor" description="Placeholder" link="abioticfactor-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/ktTGqHAKnPH6rya/preview"/>
-    <Card title="American Truck Simulator" description="Placeholder" link="ats-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/MEJfqyT5YwYpjpW/preview"/>
-    <Card title="Among Us" description="Placeholder" link="amongus-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/56aajb26cS6Lda3/preview"/>
-    <Card title="ARK" description="Placeholder" link="ark-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/qnWELD8ik9srBDG/preview"/>
-    <Card title="Arma 3" description="Placeholder" link="arma3-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/J3X8RGWSZ5MgFNq/preview"/>
-    <Card title="Assetto Corsa" description="Placeholder" link="assettocorsa-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/z8SQ7C2fkcJmWYj/preview"/>
-    <Card title="Assetto Corsa (Comp.)" description="Placeholder" link="assetto-competizione-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/oLbXej9nzXPc6Kr/preview"/>
-    <Card title="Avorion" description="Placeholder" link="avorion-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/FGtbBbgYsjygaHQ/preview"/>
-    <Card title="Barotrauma" description="Placeholder" link="barotrauma-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/CRf8AAmcXwAReHT/preview"/>
-    <Card title="BeamMP" description="Placeholder" link="beammp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/XLLGT8nMkoXKYtC/preview"/>
-    <Card title="Conan Exiles" description="Placeholder" link="conan-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Kf4Agc6HXkEMJGM/preview"/>
-    <Card title="Core Keeper" description="Placeholder" link="corekeeper-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/RsHHfMtbAdY4pJf/preview"/>
-    <Card title="CS 1.6" description="Placeholder" link="cs16-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/q5enKNatKZMpXPf/preview"/>
-    <Card title="CS:GO" description="Placeholder" link="csgo-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/cSkWS3sQb22s5f8/preview"/>
-    <Card title="CS:S" description="Placeholder" link="css-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/PqQqSqgin9BjJtw/preview"/>
-    <Card title="CS2" description="Placeholder" link="cs2-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/cSkWS3sQb22s5f8/preview"/>
-    <Card title="DayZ" description="Placeholder" link="dayz-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/pnsf69ApNAWxzEa/preview"/>
-    <Card title="Don't Starve Together" description="Placeholder" link="dst-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/rtFRzgDkWPZodc4/preview"/>
-    <Card title="ECO" description="Placeholder" link="eco-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/XiHGRrHtkqnsNF7/preview"/>
-    <Card title="Empyrion" description="Placeholder" link="empyrion-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/xYyDybq5znjy3HR/preview"/>
-    <Card title="Enshrouded" description="Placeholder" link="enshrouded-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/65zgmLrBtcPTt7k/preview"/>
-    <Card title="Euro Truck Simulator" description="Placeholder" link="ets2-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/yZX6rF6emyBbrgq/preview"/>
-    <Card title="Factorio" description="Placeholder" link="factorio-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/iZeioXS2ZPHrnjq/preview"/>
-    <Card title="FiveM" description="Placeholder" link="fivem-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/2JA2yD8CgCpn3nZ/preview"/>
-    <Card title="Foundry" description="Placeholder" link="foundry-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/meb8kopKD3WETbt/preview"/>
-    <Card title="Garry's Mod" description="Placeholder" link="gmod-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/LddW8FyQ2ZKKTzN/preview"/>
-    <Card title="Last Oasis" description="Placeholder" link="lastoasis-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/3CwdeqDaikA6Mp8/preview"/>
-    <Card title="Minecraft" description="Placeholder" link="minecraft-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/nQ5nkPeAN25dJaf/preview"/>
-    <Card title="Multi Theft Auto" description="Placeholder" link="mta-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/MjAJfQFWBprjdk3/preview"/>
-    <Card title="Myth of Empires" description="Placeholder" link="moe-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/W8rBp8LESZidDLs/preview"/>
-    <Card title="Open.mp" description="Placeholder" link="openmp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/JwKCDWdigbHag3C/preview"/>
-    <Card title="Palworld" description="Placeholder" link="palworld-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/RgdKJoRRNBPcT5r/preview"/>
-    <Card title="Project Zomboid" description="Placeholder" link="projectzomboid-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/tYJB3JWdG9ewAmf/preview"/>
-    <Card title="RedM" description="Placeholder" link="redm-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/9HTK29mQCHe5kNs/preview"/>
-    <Card title="RimWorld Together" description="Placeholder" link="rimworldtogether-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/7PBDBpc2ysJPWdA/preview"/>
-    <Card title="Rust" description="Placeholder" link="rust-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/G82jnYsbexscj5W/preview"/>
-    <Card title="Satisfactory" description="Placeholder" link="satisfactory-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/JFfEJs6E5ExjYmD/preview"/>
-    <Card title="SCP: Secret Laboratory" description="Placeholder" link="scp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/b5qWPyQeoB5wN8s/preview"/>
-    <Card title="Space Engineers" description="Placeholder" link="spaceengineers-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Wi29doTRKNHGn2a/preview"/>
-    <Card title="Stormworks" description="Placeholder" link="stormworks-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/wzDPFmpDJ8oZTtW/preview"/>
-    <Card title="Sunkenland" description="Placeholder" link="sunkenland-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/F8eyGq2GjKYcNcb/preview"/>
-    <Card title="Terraria" description="Placeholder" link="terraria-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/eByW7ZDwsmySJr9/preview"/>
-    <Card title="Terratech Worlds" description="Placeholder" link="terratech-worlds-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Sf4LScK23KCxzDF/preview"/>
-    <Card title="Unturned" description="Placeholder" link="unturned-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/GTxekqqTxQyttDS/preview"/>
-    <Card title="Valheim" description="Placeholder" link="valheim-firststeps-dashboard"  image="https://screensaver01.zap-hosting.com/index.php/s/LSiFMXMmyKgo4LG/preview"/>
-    <Card title="Vein" description="Placeholder" link="vein-firststeps-dashboard"  image="https://screensaver01.zap-hosting.com/index.php/s/mBkRqP68YrDmdop/preview"/>
-    <Card title="V Rising" description="Placeholder" link="vrising-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/xazMeLwLJTJG7LF/preview"/>
-    <Card title="Wurm Unlimited" description="Placeholder" link="wurmunlimited-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/BzbDjJWySW4LjtX/preview"/>
+    <Card title="7 Days to Die" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/7d2d-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/dXbYWLtmqHnAz8n/preview"/>
+    <Card title="Abiotic Factor" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/abioticfactor-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/ktTGqHAKnPH6rya/preview"/>
+    <Card title="American Truck Simulator" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/ats-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/MEJfqyT5YwYpjpW/preview"/>
+    <Card title="Among Us" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/amongus-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/56aajb26cS6Lda3/preview"/>
+    <Card title="ARK" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/ark-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/qnWELD8ik9srBDG/preview"/>
+    <Card title="Arma 3" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/arma3-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/J3X8RGWSZ5MgFNq/preview"/>
+    <Card title="Assetto Corsa" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/assettocorsa-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/z8SQ7C2fkcJmWYj/preview"/>
+    <Card title="Assetto Corsa (Comp.)" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/assetto-competizione-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/oLbXej9nzXPc6Kr/preview"/>
+    <Card title="Avorion" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/avorion-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/FGtbBbgYsjygaHQ/preview"/>
+    <Card title="Barotrauma" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/barotrauma-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/CRf8AAmcXwAReHT/preview"/>
+    <Card title="BeamMP" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/beammp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/XLLGT8nMkoXKYtC/preview"/>
+    <Card title="Conan Exiles" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/conan-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Kf4Agc6HXkEMJGM/preview"/>
+    <Card title="Core Keeper" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/corekeeper-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/RsHHfMtbAdY4pJf/preview"/>
+    <Card title="CS 1.6" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/cs16-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/q5enKNatKZMpXPf/preview"/>
+    <Card title="CS:GO" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/csgo-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/cSkWS3sQb22s5f8/preview"/>
+    <Card title="CS:S" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/css-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/PqQqSqgin9BjJtw/preview"/>
+    <Card title="CS2" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/cs2-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/cSkWS3sQb22s5f8/preview"/>
+    <Card title="DayZ" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/dayz-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/pnsf69ApNAWxzEa/preview"/>
+    <Card title="Don't Starve Together" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/dst-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/rtFRzgDkWPZodc4/preview"/>
+    <Card title="ECO" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/eco-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/XiHGRrHtkqnsNF7/preview"/>
+    <Card title="Empyrion" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/empyrion-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/xYyDybq5znjy3HR/preview"/>
+    <Card title="Enshrouded" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/enshrouded-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/65zgmLrBtcPTt7k/preview"/>
+    <Card title="Euro Truck Simulator" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/ets2-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/yZX6rF6emyBbrgq/preview"/>
+    <Card title="Factorio" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/factorio-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/iZeioXS2ZPHrnjq/preview"/>
+    <Card title="FiveM" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/fivem-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/2JA2yD8CgCpn3nZ/preview"/>
+    <Card title="Foundry" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/foundry-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/meb8kopKD3WETbt/preview"/>
+    <Card title="Garry's Mod" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/gmod-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/LddW8FyQ2ZKKTzN/preview"/>
+    <Card title="Last Oasis" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/lastoasis-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/3CwdeqDaikA6Mp8/preview"/>
+    <Card title="Minecraft" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/minecraft-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/nQ5nkPeAN25dJaf/preview"/>
+    <Card title="Multi Theft Auto" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/mta-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/MjAJfQFWBprjdk3/preview"/>
+    <Card title="Myth of Empires" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/moe-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/W8rBp8LESZidDLs/preview"/>
+    <Card title="Open.mp" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/openmp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/JwKCDWdigbHag3C/preview"/>
+    <Card title="Palworld" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/palworld-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/RgdKJoRRNBPcT5r/preview"/>
+    <Card title="Project Zomboid" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/projectzomboid-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/tYJB3JWdG9ewAmf/preview"/>
+    <Card title="RedM" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/redm-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/9HTK29mQCHe5kNs/preview"/>
+    <Card title="RimWorld Together" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/rimworldtogether-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/7PBDBpc2ysJPWdA/preview"/>
+    <Card title="Rust" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/rust-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/G82jnYsbexscj5W/preview"/>
+    <Card title="Satisfactory" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/satisfactory-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/JFfEJs6E5ExjYmD/preview"/>
+    <Card title="SCP: Secret Laboratory" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/scp-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/b5qWPyQeoB5wN8s/preview"/>
+    <Card title="Space Engineers" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/spaceengineers-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Wi29doTRKNHGn2a/preview"/>
+    <Card title="Stormworks" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/stormworks-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/wzDPFmpDJ8oZTtW/preview"/>
+    <Card title="Sunkenland" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/sunkenland-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/F8eyGq2GjKYcNcb/preview"/>
+    <Card title="Terraria" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/terraria-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/eByW7ZDwsmySJr9/preview"/>
+    <Card title="Terratech Worlds" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/terratech-worlds-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/Sf4LScK23KCxzDF/preview"/>
+    <Card title="Unturned" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/unturned-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/GTxekqqTxQyttDS/preview"/>
+    <Card title="Valheim" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/valheim-firststeps-dashboard"  image="https://screensaver01.zap-hosting.com/index.php/s/LSiFMXMmyKgo4LG/preview"/>
+    <Card title="Vein" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/vein-firststeps-dashboard"  image="https://screensaver01.zap-hosting.com/index.php/s/mBkRqP68YrDmdop/preview"/>
+    <Card title="V Rising" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/vrising-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/xazMeLwLJTJG7LF/preview"/>
+    <Card title="Wurm Unlimited" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/wurmunlimited-firststeps-dashboard" image="https://screensaver01.zap-hosting.com/index.php/s/BzbDjJWySW4LjtX/preview"/>
 </Cards>
 
 ## vRootserver
 Nutze den vollen Umfang deines vRootservers (VPS/Rootserver) mit unseren umfassenden Anleitungen. Egal, ob du Linux oder Windows bevorzugst, Anleitungen helfen dir, deinen Server effizient einzurichten und zu verwalten.
 
 <Cards>
-    <Card title="vServer (Linux)" description="Placeholder" link="vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/XmJGtYkc7d9rBai/preview" type="product-categories"/>
-    <Card title="vServer (Windows)" description="Placeholder" link="vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/XmJGtYkc7d9rBai/preview" type="product-categories"/>
-    <Card title="Rootserver (Linux)" description="Placeholder" link="vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/fqn5SZYRJjoikXa/preview" type="product-categories"/>
-    <Card title="Rootserver (Windows)" description="Placeholder" link="vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/fqn5SZYRJjoikXa/preview" type="product-categories"/>
+    <Card title="vServer (Linux)" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/XmJGtYkc7d9rBai/preview" type="product-categories"/>
+    <Card title="vServer (Windows)" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/XmJGtYkc7d9rBai/preview" type="product-categories"/>
+    <Card title="Rootserver (Linux)" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/fqn5SZYRJjoikXa/preview" type="product-categories"/>
+    <Card title="Rootserver (Windows)" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/vserver-root-difference" image="https://screensaver01.zap-hosting.com/index.php/s/fqn5SZYRJjoikXa/preview" type="product-categories"/>
 </Cards>
 
 ## Dedicated Server
 Unsere Dedicated Server bieten Leistung für anspruchsvolle Projekte. Entdecke in unseren Anleitungen, wie du die Hardware und Betriebssysteme nach deinen Bedürfnissen konfigurierst und sicherstellst, dass deine Anwendungen optimal laufen.
 
 <Cards>
-    <Card title="Dedicated Server" description="Placeholder" link="dedicated-introduction" image="https://screensaver01.zap-hosting.com/index.php/s/o5kTJsSdwGY69m8/preview" type="product-categories"/>
+    <Card title="Dedicated Server" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/dedicated-introduction" image="https://screensaver01.zap-hosting.com/index.php/s/o5kTJsSdwGY69m8/preview" type="product-categories"/>
 </Cards>
 
 ## Domain & Webspace
 Beginne dein Online-Projekt auf festem Fundament mit leicht verständlichen Anleitungen zu Domain-Registrierung und Webspace-Management. Wir führen dich durch jeden Schritt. Von der Einrichtung bis zur Veröffentlichung deiner Website.
 
 <Cards>
-    <Card title="Domain" description="Placeholder" link="domain-introduction" image="https://screensaver01.zap-hosting.com/index.php/s/CHKT8d4ARD8sqZE/preview" type="product-categories"/>
-    <Card title="Webspace" description="Placeholder" link="webspace-adddomain" image="https://screensaver01.zap-hosting.com/index.php/s/CHKT8d4ARD8sqZE/preview" type="product-categories"/>
+    <Card title="Domain" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/domain-introduction" image="https://screensaver01.zap-hosting.com/index.php/s/CHKT8d4ARD8sqZE/preview" type="product-categories"/>
+    <Card title="Webspace" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/webspace-adddomain" image="https://screensaver01.zap-hosting.com/index.php/s/CHKT8d4ARD8sqZE/preview" type="product-categories"/>
 </Cards>
 
 ## Voicebot & Voiceserver
 Verbessere deine Online-Interaktionen mit unseren Voicebots und Voiceservern. Unsere Anleitungen machen die Einrichtung einfach, sodass du mehr Zeit mit deiner Community verbringen kannst, sei es beim Gaming oder in Meetings.
 
 <Cards>
-    <Card title="Voicebot" description="Placeholder" link="voiceserver-voicebot-connection" image="https://screensaver01.zap-hosting.com/index.php/s/zZ73fps5Eq93foK/preview" type="product-categories"/>
-    <Card title="Voiceserver" description="Placeholder" link="voiceserver-becomeadmin" image="https://screensaver01.zap-hosting.com/index.php/s/6cxS6Mo93YL6X5K/preview" type="product-categories"/>
+    <Card title="Voicebot" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/voiceserver-voicebot-connection" image="https://screensaver01.zap-hosting.com/index.php/s/zZ73fps5Eq93foK/preview" type="product-categories"/>
+    <Card title="Voiceserver" description="Placeholder" link="https://zap-hosting.com/guides/de/docs/voiceserver-becomeadmin" image="https://screensaver01.zap-hosting.com/index.php/s/6cxS6Mo93YL6X5K/preview" type="product-categories"/>
 </Cards>

--- a/src/theme/DocItem/Footer/GitHubContributors.js
+++ b/src/theme/DocItem/Footer/GitHubContributors.js
@@ -62,13 +62,13 @@ const GitHubContributors = ({ owner, repo, filePath, additionalContributors }) =
                 <Translate id="contributors.description"
                 values={{
                     contributionLink: (
-                        <a href="contribution-introduction">
+                        <a href="https://zap-hosting.com/guides/docs/contribution-introduction/">
                             Contribution Program
                         </a>
                     ),
                 }}>
                 {
-                    'Become a part of the ZAP-Hosting Community today! Join our {contributionLink} to share your knowledge and expertise by producing high-quality guides & creative content whilst earning valuable rewards (up to €130). Begin today and make a difference! 🙂'
+                    'Become a part of the ZAP-Hosting Community today! Join our {contributionLink} to share your knowledge and expertise by producing high-quality guides & creative content whilst earning valuable rewards up to 130€. Begin today and make a difference! 🙂'
                 }
                 </Translate>
             </p>


### PR DESCRIPTION
This hotfix resolves the issue with the internal links from react components with the use of the "@docusaurus/Translate"function in the documentation. All affected internal links have been replaced with full direct links to avoid errors in the URL structure caused by the trailing slash problem in productive use. This should eliminate all 404 errors after page reloads for the users and indexing/console with Google. 

**Disclaimer:** This is not intended to be an optimal or final solution. It is a temporary solution until a long-term and better solution is developed.