### PR TITLE
Improve translation process to detect all changed markdown files in PR

### DIFF
--- a/translate.js
+++ b/translate.js
@@ -46,7 +46,7 @@ function buildSystemPrompt(targetLang) {
 
 function getChangedMarkdownFiles() {
   try {
-    const output = execSync('git diff --name-only HEAD~1 HEAD', { encoding: 'utf8' });
+    const output = execSync('git diff --name-only origin/main...HEAD', { encoding: 'utf8' });
     return output
       .split('\n')
       .filter(file => file.startsWith(SOURCE_DIR) && file.endsWith('.md') && fs.existsSync(file));


### PR DESCRIPTION
Changed git diff command from `HEAD~1 HEAD` to `origin/main...HEAD` to ensure all modified markdown files across the entire PR are translated, not just changes from the last commit.