### PR TITLE
Update gameserver price values

### DIFF
--- a/src/utilities/services.map.tsx
+++ b/src/utilities/services.map.tsx
@@ -820,7 +820,7 @@ const servicesMap: serviceMap = {
             id: 'service.gameserver-foundry.path',
             description: 'URL path for the gameserver product',
         }),
-        price: `${priceFrom} 7.90€`,
+        price: `${priceFrom} 6.32€`,
     },
     'gameserver-gmod': {
         title: translate({
@@ -1509,7 +1509,7 @@ const servicesMap: serviceMap = {
             id: 'service.gameserver-scp.path',
             description: 'URL path for the gameserver product',
         }),
-        price: `${priceFrom} 2.76€`,
+        price: `${priceFrom} 5.90€`,
     },
     'gameserver-scum': {
         title: translate({
@@ -1886,7 +1886,7 @@ const servicesMap: serviceMap = {
             id: 'service.gameserver-voyagers-of-nera.path',
             description: 'URL path for the gameserver product',
         }),
-        price: `${priceFrom} 4.14€`,
+        price: `${priceFrom} 5.96€`,
     },
     'gameserver-wreckfest': {
         title: translate({


### PR DESCRIPTION
Update displayed starting prices in src/utilities/services.map.tsx for several gameserver entries: gameserver-foundry (7.90€ → 6.32€), gameserver-scp (2.76€ → 5.90€), and gameserver-voyagers-of-nera (4.14€ → 5.96€). These changes adjust the price strings used in the UI.