### PR TITLE
[codex] Experimental Docusaurus build process time optimization

### DIFF
--- a/.github/workflows/build-docusaurus.yml
+++ b/.github/workflows/build-docusaurus.yml
@@ -26,27 +26,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+
+      - name: Restore Docusaurus caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            .docusaurus
+            node_modules/.cache
+          key: ${{ runner.os }}-docusaurus-${{ hashFiles('package-lock.json', 'docusaurus.config.js') }}
+          restore-keys: |
+            ${{ runner.os }}-docusaurus-
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build Docusaurus
         run: |
-          npm run write-translations -- --locale de
-          npm run write-translations -- --locale es
-          npm run write-translations -- --locale fr
-          npm run write-translations -- --locale ar
-          npm run write-translations -- --locale pt
-          npm run write-translations -- --locale th
-          npm run write-translations -- --locale pl
-          npm run write-translations -- --locale ja   
-          npm run write-translations -- --locale sv
-          npm run write-translations -- --locale it
-          npm run write-translations -- --locale nl
-          npm run write-translations -- --locale zh
-
-          rm -rf build
-          npm run docusaurus clear
           rm -f build.tar
           npm run build
           tar cf build.tar -C build --transform 's~^\./~~' .

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,7 +104,7 @@ const config = {
     [
       '@docusaurus/plugin-pwa',
       {
-        debug: true,
+        debug: false,
         offlineModeActivationStrategies: [
           'appInstalled',
           'standalone',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,16 @@
       "name": "docusaurus",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.9.2",
-        "@docusaurus/faster": "^3.9.2",
-        "@docusaurus/plugin-client-redirects": "^3.9.2",
-        "@docusaurus/plugin-content-docs": "^3.9.2",
-        "@docusaurus/plugin-google-tag-manager": "^3.9.2",
-        "@docusaurus/plugin-pwa": "^3.9.2",
-        "@docusaurus/plugin-sitemap": "^3.9.2",
-        "@docusaurus/preset-classic": "^3.9.2",
-        "@docusaurus/theme-classic": "^3.9.2",
-        "@docusaurus/theme-mermaid": "^3.9.2",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/faster": "3.9.2",
+        "@docusaurus/plugin-client-redirects": "3.9.2",
+        "@docusaurus/plugin-content-docs": "3.9.2",
+        "@docusaurus/plugin-google-tag-manager": "3.9.2",
+        "@docusaurus/plugin-pwa": "3.9.2",
+        "@docusaurus/plugin-sitemap": "3.9.2",
+        "@docusaurus/preset-classic": "3.9.2",
+        "@docusaurus/theme-classic": "3.9.2",
+        "@docusaurus/theme-mermaid": "3.9.2",
         "@mdx-js/react": "^3.1.0",
         "body-parser": "^2.2.1",
         "clsx": "^2.1.1",
@@ -43,8 +43,8 @@
         "webpack": "^5.106.2"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.9.2",
-        "@docusaurus/types": "^3.9.2",
+        "@docusaurus/module-type-aliases": "3.9.2",
+        "@docusaurus/types": "3.9.2",
         "baseline-browser-mapping": "^2.10.20"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -14,16 +14,16 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.9.2",
-    "@docusaurus/faster": "^3.9.2",
-    "@docusaurus/plugin-client-redirects": "^3.9.2",
-    "@docusaurus/plugin-content-docs": "^3.9.2",
-    "@docusaurus/plugin-google-tag-manager": "^3.9.2",
-    "@docusaurus/plugin-pwa": "^3.9.2",
-    "@docusaurus/plugin-sitemap": "^3.9.2",
-    "@docusaurus/preset-classic": "^3.9.2",
-    "@docusaurus/theme-classic": "^3.9.2",
-    "@docusaurus/theme-mermaid": "^3.9.2",
+    "@docusaurus/core": "3.9.2",
+    "@docusaurus/faster": "3.9.2",
+    "@docusaurus/plugin-client-redirects": "3.9.2",
+    "@docusaurus/plugin-content-docs": "3.9.2",
+    "@docusaurus/plugin-google-tag-manager": "3.9.2",
+    "@docusaurus/plugin-pwa": "3.9.2",
+    "@docusaurus/plugin-sitemap": "3.9.2",
+    "@docusaurus/preset-classic": "3.9.2",
+    "@docusaurus/theme-classic": "3.9.2",
+    "@docusaurus/theme-mermaid": "3.9.2",
     "@mdx-js/react": "^3.1.0",
     "body-parser": "^2.2.1",
     "clsx": "^2.1.1",
@@ -49,8 +49,8 @@
     "webpack": "^5.106.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.9.2",
-    "@docusaurus/types": "^3.9.2",
+    "@docusaurus/module-type-aliases": "3.9.2",
+    "@docusaurus/types": "3.9.2",
     "baseline-browser-mapping": "^2.10.20"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary
This experimental PR reduces Docusaurus build process time without upgrading to Docusaurus 3.10.

## What changed
- pin all Docusaurus packages to `3.9.2` to prevent accidental drift to `3.10.x`
- switch the build workflow from `npm install` to `npm ci`
- enable npm dependency caching in GitHub Actions
- persist `.docusaurus` and `node_modules/.cache` so Docusaurus/Rspack caches can speed up follow-up builds
- remove redundant `write-translations` runs from the build workflow
- stop clearing Docusaurus caches before every build
- disable PWA debug mode for production builds

## Why
The repo already had Docusaurus faster mode enabled for `3.9.x`, but the build process was still doing avoidable extra work:
- package ranges allowed local installs to drift to `3.10.x`, which breaks the current `future.experimental_faster` config
- the CI workflow removed caches before each run, which prevented the faster build path from paying off on subsequent builds
- the workflow regenerated translation scaffolding even though the checked-in `i18n` content is already available for builds

## Impact
- safer and reproducible installs on Docusaurus `3.9.2`
- faster repeat builds in CI thanks to preserved caches
- less unnecessary work in the build workflow

## Validation
- `npm ls @docusaurus/core @docusaurus/faster`
- `npm run build -- --locale en`
  - successful build on `@docusaurus/core@3.9.2`
  - local single-locale build completed in about 71s during verification

## Notes
- this PR is intentionally marked as a draft because it changes CI behavior and should be observed on the first workflow runs
- the biggest remaining time driver is the full multi-locale build plus Lunr indexing per locale
