### PR TITLE
Fix duplicate Subnautica 2 sidebar translation key

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -4355,13 +4355,6 @@ const sidebars = {
           key: "gameserver-troubleshooting-subnautica-2",
           items: [
             "subnautica-2-mods",
-          ]
-        },
-        {
-          type: "category",
-          label: "Troubleshooting",
-          key: "gameserver-troubleshooting-subnautica-2",
-          items: [
             "subnautica-2-common-issues",
           ]
         },


### PR DESCRIPTION
## Summary
- Merge the duplicate Subnautica 2 Troubleshooting sidebar categories introduced in #1797
- Fixes the Docusaurus build failure: Multiple docs sidebar items produce the same translation key

## Test plan
- [x] 
pm run write-translations -- --locale de completes successfully locally
- [ ] uild-docusaurus GitHub Actions workflow passes on this PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Subnautica 2 troubleshooting section in the documentation sidebar to include guides for mods and common issues, making these resources more easily accessible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zaphosting/docs/pull/1799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->